### PR TITLE
Got Activities

### DIFF
--- a/gotissues/data_helpers.py
+++ b/gotissues/data_helpers.py
@@ -40,11 +40,13 @@ else:
 #
 choice_dict = {
     "clicked_issues": {
+      'start_date':'today',
+      'end_date':'today',
       'metrics':'ga:totalEvents',
       'dimensions':'ga:eventLabel',
       'sort':'-ga:totalEvents',
       'filters':'ga:eventCategory==Civic Issues;ga:eventLabel=@github.com',
-      'max_results':None,
+      'max_results':10000,
       'fields':None
     },
 
@@ -103,6 +105,8 @@ choice_dict = {
     },
 
     "viewed_issues": {
+      'start_date':'today',
+      'end_date':'today',
       'metrics':'ga:totalEvents',
       'dimensions':'ga:eventLabel',
       'sort':'-ga:totalEvents',
@@ -112,11 +116,13 @@ choice_dict = {
     },
 
     "all_clicks": {
+      'start_date':'today',
+      'end_date':'today',
       'metrics':'ga:totalEvents',
       'dimensions':'ga:eventLabel, ga:dateHour, ga:minute',
       'sort':'-ga:dateHour',
       'filters':'ga:eventCategory==Civic Issues;ga:eventLabel=@github.com',
-      'max_results':10,
+      'max_results':10000,
       'fields':'rows'
     },
 }
@@ -124,8 +130,8 @@ choice_dict = {
 def edit_request_query(choice_dict_query):
   results = service.data().ga().get(
           ids="ga:" + GOOGLE_ANALYTICS_PROFILE_ID,
-          start_date='2014-08-24',
-          end_date=datetime.date.today().strftime("%Y-%m-%d"),
+          start_date=choice_dict[choice_dict_query].get("start_date",'2014-08-24'),
+          end_date=choice_dict[choice_dict_query].get("end_date", datetime.date.today().strftime("%Y-%m-%d")),
           metrics=choice_dict[choice_dict_query]['metrics'],
           dimensions=choice_dict[choice_dict_query]['dimensions'],
           sort=choice_dict[choice_dict_query]['sort'],
@@ -281,15 +287,42 @@ def get_github_project_data(issue_url):
 
 def get_click_activity(clicks):
   activities = []
+  total = 0
   for click in clicks:
-    # issue_activity.append(get_github_project_data(click["issue_url"]))
     activity_list = get_github_project_data(click["issue_url"])
-    # print activity_list
     for activity in activity_list:
-      trimmed_activity = trim_activity(activity, click)
-      activities.append(trimmed_activity)
-      # print str(trimmed_activity) + "\n"
+      if check_timestamp(activity, click, 5):
+        trimmed_activity = trim_activity(activity, click)
+        activities.append(trimmed_activity)
+      print str(trimmed_activity) + "\n"
   return activities
+
+def write_activities_to_db(activity, db):
+    # print "This is the activity we are trying to write"
+    # print activity
+    q = ''' SELECT * FROM activity WHERE activity_type = %(activity_type)s AND activity_timestamp = %(activity_timestamp)s AND click_timestamp = %(click_timestamp)s'''
+
+    db.execute(q, {"issue_id": activity["issue_id"], "issue_url": activity["issue_url"],
+                "click_timestamp": activity["click_timestamp"], "activity_type": activity["activity_type"],
+                "activity_timestamp": activity["activity_timestamp"]})
+
+    q = ''' INSERT INTO activity (issue_id, issue_url, click_timestamp, activity_type, activity_timestamp)
+            VALUES ( %(issue_id)s, %(issue_url)s, %(click_timestamp)s, %(activity_type)s, %(activity_timestamp)s)
+        '''
+    db.execute(q, {"issue_id": activity["issue_id"], "issue_url": activity["issue_url"],
+               "click_timestamp": activity["click_timestamp"], "activity_type": activity["activity_type"],
+               "activity_timestamp": activity["activity_timestamp"]})
+
+def check_timestamp(activity, click, hours):
+
+  action_time = datetime.datetime.strptime(activity["created_at"], '%Y-%m-%dT%H:%M:%SZ')
+  # click_time = datetime.datetime.strptime(click["timestamp"], '%Y-%m-%dT%H:%M:%S')
+  click_time = click["timestamp"]
+  timedelta = action_time - click_time
+  if timedelta < datetime.timedelta(hours=hours) and timedelta > datetime.timedelta(minutes=0):
+    print timedelta
+    return True
+  else: return False
 
 def trim_activity(activities, db_data):
   # print activities

--- a/scripts/002-clicked-activity.pgsql
+++ b/scripts/002-clicked-activity.pgsql
@@ -1,19 +1,12 @@
 --
--- Table of clicked Github Issue data
+-- Table of clicked Github activity data
 --
 
 CREATE TABLE activity
 (
-
-    clicked_at        TIMESTAMP,
-
-    -- Issue id is the issue that the click is related to
-    issue_id          INT PRIMARY KEY,
-    nearby_events     TEXT[],
-    fork_count        INT,
-    watch_count       INT,
-    push_count        INT,
-    issue_count       INT,
-    pr_count          INT
-
+    issue_id           INT,
+    issue_url          TEXT,
+    click_timestamp    TIMESTAMP,
+    activity_type      TEXT,
+    activity_timestamp TIMESTAMP
 );

--- a/tests/testdata.py
+++ b/tests/testdata.py
@@ -4,7 +4,15 @@ fake_click = {
     "issue_url":"https://github.com/codeforamerica/gotissues/issues/8",
     "timestamp":"2015-12-27T07:30:00",
     "readable_date":"Sunday, December 27 2015 07:30AM"
-} 
+}
+
+fake_activity = {
+  "issue_id": 111111,
+  "issue_url": "https://github.com/codeforamerica/gotissues/issues/8",
+  "click_timestamp": "2015-12-27 07:30:00"
+  "activity_type": "PushEvent",
+  "activity_timestamp": "2015-06-06 23:16:56"
+}
 
 full_issue = {
   "url": "https://api.github.com/repos/codeforamerica/gotissues/issues/8",

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -99,6 +99,16 @@ class GotIssuesTestCase(unittest.TestCase):
                 issue = db.fetchone()
                 self.assertEqual(issue["id"],1)
                 self.assertEqual(issue["readable_date"],"Sunday, December 27 2015 07:30AM")
+    
+    def test_write_activity_to_db(self):
+        with connect(testdata.DATABASE_URL) as conn:
+            with db_cursor(conn) as db:
+                daily_update.write_activities_to_db(testdata.fake_db_click, db)
+
+                q = ''' SELECT * FROM activity '''
+                db.execute(q)
+                activity = db.fetchone()
+                self.assertEqual(activity["issue_id"],111111)
 
     # Test for valid timestamps
     # Capture datetime.datetime.now() and the month year day 


### PR DESCRIPTION
From #20, we talked about the activity surrounding a click, so based on every click in the database, we look at different types of github activity in that project.

The complete list of events that can happen in a project are available on the [from the Github API page](https://developer.github.com/v3/activity/events/types/) and there's a lot of activity I'm adding to the db that we didn't talk about asking for, but it won't harm to have them for now.

There are two questions I have right now, should we skip over activity types that we don't want and should we filter by timestamps within 2 hours before putting it into the db?

I thought this was a problem when writing the code for it, but I rationalized that it wasn't, hopefully this is true --> I noticed there is probably some overlap in timestamp activity, because right now the way I'm getting activity is if there is 1 click on an issue I'm getting the activity for that repository. So that means if there are more clicks on something in that repository, I'm getting the same activity queried. But then I realized that's exactly we want and that is the only way we can correlate activity.

Otherwise, I might have to write a good test for this and will add it to the PR by the end of today!
