### PR TITLE
Daily update

### DIFF
--- a/gotissues/daily_update.py
+++ b/gotissues/daily_update.py
@@ -1,6 +1,5 @@
 import json
 from data_helpers import *
-from github_bot import *
 
 def get_clicked_issue_github_data(clicked_issues, limit=None):
     """ Get all the github data about all the clicked issues """
@@ -146,26 +145,79 @@ def write_activity_summary_to_db(activity_info, db):
 
 
 if __name__ == '__main__':
+    import sys
+    if len(sys.argv) == 1:
+        # Get todays clicked issues from Google Analytics
+        clicked_issues = get_analytics_query("clicked_issues")
+        # Get todays viewed issues from Google Analytics
+        viewed_issues = get_analytics_query("viewed_issues")
 
-    # Get todays clicked issues from Google Analytics
-    clicked_issues = get_analytics_query("clicked_issues")
-    # Get todays viewed issues from Google Analytics
-    viewed_issues = get_analytics_query("viewed_issues")
+        # Get the Github data for todays clicked issues, clicks, and views
+        # Set the limit to 1 for testing
+        github_issues = get_clicked_issue_github_data(clicked_issues, limit=None)
+        trimmed_issues = trim_github_issues(github_issues)
+        issues = add_views_to_issues(github_issues, viewed_issues)
 
-    # Get the Github data for todays clicked issues, clicks, and views
-    # Set the limit to 1 for testing
-    github_issues = get_clicked_issue_github_data(clicked_issues, limit=None)
-    trimmed_issues = trim_github_issues(github_issues)
-    issues = add_views_to_issues(github_issues, viewed_issues)
+        # Get all of todays clicks
+        clicks = get_analytics_query("all_clicks")
 
-    # Get all of todays clicks
-    clicks = get_analytics_query("all_clicks")
+        # Get all of todays clicks activity
+        activities = get_click_activity(clicks)
 
-    # Get all of todays clicks activity
-    activities = get_click_activity(clicks)
+    elif len(sys.argv) == 2:
+        args = sys.argv
+
+        if args[1] == "all":
+            print "Updating All Databases From Default Start Date"
+            # Get todays clicked issues from Google Analytics
+            clicked_issues = get_analytics_query("clicked_issues_total")
+            # Get todays viewed issues from Google Analytics
+            viewed_issues = get_analytics_query("viewed_issues_total")
+
+            # Get the Github data for todays clicked issues, clicks, and views
+            # Set the limit to 1 for testing
+            github_issues = get_clicked_issue_github_data(clicked_issues, limit=5)
+            trimmed_issues = trim_github_issues(github_issues)
+            issues = add_views_to_issues(github_issues, viewed_issues)
+
+            # Get all of todays clicks
+            clicks = get_analytics_query("all_clicks_total")
+
+            # Get all of todays clicks activity
+            activities = get_click_activity(clicks)
+
+        elif args[1] == "issues":
+            print "Updating issues Database From Default Start Date"
+            # Get todays clicked issues from Google Analytics
+            clicked_issues = get_analytics_query("clicked_issues_total")
+            # Get todays viewed issues from Google Analytics
+            viewed_issues = get_analytics_query("viewed_issues_total")
+
+            # Get the Github data for todays clicked issues, clicks, and views
+            # Set the limit to 1 for testing
+            github_issues = get_clicked_issue_github_data(clicked_issues, limit=5)
+            trimmed_issues = trim_github_issues(github_issues)
+            issues = add_views_to_issues(github_issues, viewed_issues)
+
+        elif args[1] == "clicks":
+            print "Updating clicks Database From Default Start Date"
+            # Get all of todays clicks
+            clicks = get_analytics_query("all_clicks_total")
+
+        elif args[1] == "activities":
+            print "Updating activities Database From Default Start Date"
+            # Get all of todays clicks
+            clicks = get_analytics_query("all_clicks_total")
+
+            # Get all of todays clicks activity
+            activities = get_click_activity(clicks)
+
+        else:
+            print "Not a valid argument"
+            sys.exit()
 
 
-    #Add each issue to the db
+    #Add each to the db
     with connect(os.environ['DATABASE_URL']) as conn:
         with dict_cursor(conn) as db:
             for issue in issues:

--- a/gotissues/templates/index.html
+++ b/gotissues/templates/index.html
@@ -142,14 +142,14 @@
           </div>
 
           <div class="layout-breve">
-          <div class="layout-minor block-dark-blue">
+          <div class="layout-minor block-dark-blue" style="width:15%">
               <h4> Lessons Learned about Top Clicked Issues </h4>
               <p class="icon-thumbs-up">Top clicked issues have <i>certain titles and labels</i> that were <i>more conducive</i> to being clicked on</p>
               <p class="icon-thumbs-down">Top clicked issues have been open for a long time (many since Aug 2014). Since these issues are still open, there may be something beyond the title/label preventing actual work being done. </p>
               <p class="icon-thumbs-down"> Top clicked issues don't have a ton of recent comment activity (or any activity at all). There is something about the nature of the issue that prevents having a productive conversation about that issue. </p> 
             </div>
 
-          <div class="layout-major" style="width:70%">
+          <div class="layout-major" style="width:79%">
             <h2>What Do Top Clicked Issues look like?</h2>
             <p>We crunched the numbers around why people were more likely to click on civic tech issues after seeing them through the issue finder.</p>
             <p class="icon-github2">Labels that get people excited about contributing and clicking on issues <span class="label">help wanted</span><span class="label">enhancement</span></p>
@@ -185,7 +185,7 @@
 
           <div class="layout-breve">
 
-            <div class="layout-major-invert" style="width:70%">
+            <div class="layout-major-invert" style="width:79%">
 
             <h2>What Do Less Popular Clicked Issues look like?</h2>
             <p>We also crunched the numbers around why people were less likely to click on civic tech issues after seeing them through the issue finder.</p>
@@ -217,7 +217,7 @@
 
             </div>
 
-            <div class="layout-minor-invert block-dark-blue" style="width:20%">
+            <div class="layout-minor-invert block-dark-blue" style="width:15%">
               <h4> Lessons Learned about Least Clicked Issues </h4>
               <p class="icon-thumbs-up">Maybe they're not getting viewed. Make sure to embed issues in an effective place. For example Code For San Francisco issues get the most attraction from the CFSF web site's widget embed!</p>
               <p class="icon-thumbs-down">Issues that have been open a long time and aren't getting clicked are not good. That means their titles and labels aren't interesting enough and/or they aren't getting enough screen time</p>

--- a/tests/testdata.py
+++ b/tests/testdata.py
@@ -128,13 +128,15 @@ test_issue = {
 }
 
 bad_sample_dict = {
-  "test":"",
-  "holla":""
+  "nothing":"",
+  "here":""
 }
 
 good_sample_dict = {
-  "total_clicks":""
+  "total_clicks":"",
+  "viewed_issues_total":""
 }
+
 
 ga_timestamp_row = ['https://github.com/codeforamerica/gotissues/issues/8', '2015122707', '30']
 timestamp_entry = {
@@ -147,7 +149,7 @@ test_sources_result = [('www.codeforamerica.org', 2), ('http://testurl.com', 1)]
 
 fake_issue_bad = {
     "html_url":"lalala",
-    "clicks":9000,
+    "clicks":None,
     "view_sources":[],
     "created_at": "2015-06-06 23:16:56",
     "labels":[

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -46,6 +46,21 @@ class GotIssuesTestCase(unittest.TestCase):
         for k in testdata.bad_sample_dict.iterkeys():
             testdata.bad_sample_dict[k] = data_helpers.get_analytics_query(k)
             self.assertEqual(testdata.bad_sample_dict[k], error)
+
+    def test_writing_good_GA_request(self):
+        ''' Test for logic of writing to GA since we don't wanna request to GA'''
+        def check_query(choice):
+            if choice == "total_clicks":
+                return {"row": 9000}
+
+            elif choice == "viewed_issues_total":
+                return {"html_url":"https://github.com/codeforamerica/gotissues/issues/1", "views":9000}
+
+        for k in testdata.good_sample_dict.iterkeys():
+            testdata.good_sample_dict[k] = check_query(k)
+
+        self.assertEqual(testdata.good_sample_dict["total_clicks"]["row"], 9000)
+        self.assertEqual(testdata.good_sample_dict["viewed_issues_total"]["views"], 9000)
     
 
     def test_write_timestamp(self):
@@ -56,14 +71,6 @@ class GotIssuesTestCase(unittest.TestCase):
         results = json.dumps(timestamp_response, sort_keys=True, indent=4)
 
         self.assertEqual(control, results)
-
-
-    '''def test_writing_good_GA_request(self):
-        Test that fetching from GA is working
-
-        for k in good_sample_dict.iterkeys():
-            good_sample_dict[k] = get_analytics_query(k)
-            self.assertEqual(good_sample_dict[k], error)'''
 
 
     #
@@ -148,13 +155,12 @@ class GotIssuesTestCase(unittest.TestCase):
         self.assertEqual(expected_final, returned_array)
 
     def test_post_body_to_github(self):
-        issues_array = []
-        issues_array.append(testdata.fake_issue_good)
-        issues_array.append(testdata.fake_issue_bad)
-        issues_array.append(testdata.fake_issue_bad_gov)
+        results_array = []
+        results_array.append(github_bot.get_github_post(testdata.fake_issue_bad))
+        results_array.append(github_bot.get_github_post(testdata.fake_issue_good))
 
-        for issue in issues_array:
-            print str(github_bot.get_github_post(issue)) + "\n"
+        self.assertEqual(results_array[0], "error")
+        self.assertNotEqual(results_array[1]['body'], None)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Interesting update from my last day! :) 

Okay so some of our production dbs need to be updated a little, so for specifically `clicks` or `issues` or `activities` or `all` three we can run this update one day and get the info from day 1 just by adding in an extra command line argument:

For example, running `python gotissues/daily_update.py clicks` will get all clicks ever then update their clicks table in the database only from the start date. Specifically for clicks I had to add in another call to Google Analytics so that we can start getting a record of all that clicks that are happening past 10,000.

There's a bit of redundancy, but I wanted to get a working MVP if someone else ever wanted to jump in and get fresh info. Yeah!
